### PR TITLE
pyenv-python-build: Add missing dependencies tar and findutils

### DIFF
--- a/pyenv.spec
+++ b/pyenv.spec
@@ -1,6 +1,6 @@
 Name: pyenv
 Version: 1.2.18
-Release: 1%{?dist}
+Release: 2%{?dist}
 BuildArch: noarch
 Summary: A simple Python version manager
 License: MIT
@@ -77,6 +77,8 @@ Requires: bzip2-devel
 Requires: openssl-devel
 Requires: sqlite-devel
 Requires: make
+Requires: tar
+Requires: findutils
 # Additional requirements for building jython
 Suggests: java-11-openjdk-devel
 Suggests: ant


### PR DESCRIPTION
This change is required for building python versions under minimal
fedora environments.